### PR TITLE
fixed line endings for windows drivers *.inf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+deploy/data/windows/x64/tap/windows_7/OemVista.inf eol=crlf
+deploy/data/windows/x64/tap/windows_10/OemVista.inf eol=crlf
+deploy/data/windows/x32/tap/windows_7/OemVista.inf eol=crlf
+deploy/data/windows/x32/tap/windows_10/OemVista.inf eol=crlf


### PR DESCRIPTION
Explicitly set cr-lf line endings for windows.
Possible solution for https://github.com/amnezia-vpn/desktop-client/issues/64