### PR TITLE
Add auth protection for ssh key export (Android)

### DIFF
--- a/client/android/src/org/amnezia/vpn/AuthHelper.java
+++ b/client/android/src/org/amnezia/vpn/AuthHelper.java
@@ -1,0 +1,24 @@
+package org.amnezia.vpn;
+
+import android.content.Context;
+import android.app.KeyguardManager;
+import android.content.Intent;
+import org.qtproject.qt5.android.bindings.QtActivity;
+
+
+import static android.content.Context.KEYGUARD_SERVICE;
+
+public class AuthHelper extends QtActivity {
+
+   static final String TAG = "AuthHelper";
+  
+   public static Intent getAuthIntent(Context context) {
+   	KeyguardManager mKeyguardManager = (KeyguardManager)context.getSystemService(KEYGUARD_SERVICE);
+   	if (mKeyguardManager.isDeviceSecure()) {
+                return mKeyguardManager.createConfirmDeviceCredentialIntent(null, null);
+        } else {
+        	return null;
+        }     
+   }
+   
+}

--- a/client/ui/pages_logic/ServerSettingsLogic.h
+++ b/client/ui/pages_logic/ServerSettingsLogic.h
@@ -3,6 +3,10 @@
 
 #include "PageLogicBase.h"
 
+#if defined(Q_OS_ANDROID)
+#include <QAndroidActivityResultReceiver>
+#endif
+
 class UiLogic;
 
 class ServerSettingsLogic : public PageLogicBase
@@ -34,4 +38,25 @@ public:
     ~ServerSettingsLogic() = default;
 
 };
+
+#if defined(Q_OS_ANDROID)
+/* Auth result handler for Android */
+class authResultReceiver  final : public PageLogicBase, public QAndroidActivityResultReceiver
+{
+Q_OBJECT
+
+public:
+    authResultReceiver(UiLogic *uiLogic, int serverIndex , QObject *parent = nullptr) : PageLogicBase(uiLogic, parent) {
+        m_serverIndex = serverIndex;
+    }
+    ~authResultReceiver() {}
+
+public:
+    void handleActivityResult(int receiverRequestCode, int resultCode, const QAndroidJniObject &data) override;
+
+private:
+    int  m_serverIndex;
+};
+#endif
+
 #endif // SERVER_SETTINGS_LOGIC_H


### PR DESCRIPTION
We use a builtin keyguard for ssh key export protection on Android.

This protection works only if some protection is set on the phone.

https://developer.android.com/reference/android/app/KeyguardManager#isDeviceSecure()