### PR TITLE
bugfix: import config without containers

### DIFF
--- a/client/ui/pages_logic/StartPageLogic.cpp
+++ b/client/ui/pages_logic/StartPageLogic.cpp
@@ -166,14 +166,6 @@ bool StartPageLogic::importConnection(const QJsonObject &profile)
         return false;
     }
 
-    if (!profile.contains(config_key::containers)) {
-        uiLogic()->selectedServerIndex = m_settings->defaultServerIndex();
-        uiLogic()->selectedDockerContainer = m_settings->defaultContainer(uiLogic()->selectedServerIndex);
-        uiLogic()->onUpdateAllPages();
-
-        emit uiLogic()->goToPage(Page::ServerContainers);
-    }
-
     return true;
 }
 

--- a/client/ui/pages_logic/ViewConfigLogic.cpp
+++ b/client/ui/pages_logic/ViewConfigLogic.cpp
@@ -61,7 +61,17 @@ void ViewConfigLogic::importConfig()
     m_settings->addServer(configJson());
     m_settings->setDefaultServer(m_settings->serversCount() - 1);
 
-    emit uiLogic()->goToPage(Page::Vpn);
-    emit uiLogic()->setStartPage(Page::Vpn);
+
+    if (!configJson().contains(config_key::containers) || configJson().value(config_key::containers).toArray().isEmpty()) {
+        uiLogic()->selectedServerIndex = m_settings->defaultServerIndex();
+        uiLogic()->selectedDockerContainer = m_settings->defaultContainer(uiLogic()->selectedServerIndex);
+        uiLogic()->onUpdateAllPages();
+        emit uiLogic()->goToPage(Page::Vpn);
+        emit uiLogic()->setStartPage(Page::Vpn);
+        emit uiLogic()->goToPage(Page::ServerContainers);
+    } else {
+        emit uiLogic()->goToPage(Page::Vpn);
+        emit uiLogic()->setStartPage(Page::Vpn);
+    }
 }
 


### PR DESCRIPTION
bugfix: fixed transition to the "Installed services" page when importing a config that does not have installed containers